### PR TITLE
STRIPES-545 Pin version of sanitize-html to avoid broken 1.18.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for react-intl-safe-html
 
+## 1.0.2 (IN PROGRESS)
+* Lock version of sanitize-html, fixes STRIPES-545
+
 ## [1.0.0](https://github.com/folio-org/react-intl-save-html/tree/v1.0.0) (2018-06-07)
 
 * Initial release of react-intl-safe-html

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "react-intl": "^2.3.0"
   },
   "dependencies": {
-    "sanitize-html": "^1.18.2"
+    "sanitize-html": "1.18.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/react-intl-safe-html",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "Sanitized HTML component",
   "main": "src/index.js",
   "repository": "git@github.com:folio-org/react-intl-safe-html.git",


### PR DESCRIPTION
I will follow this up with a release to npm-folio.