### PR TITLE
Support react-intl v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for react-intl-safe-html
 
+## 2.0.0 (IN PROGRESS)
+* Support `react-intl` v4. STRIPES-672
+* BREAKING: Translation strings that set element attributes are no longer supported.
+* BREAKING: `<a>` is no longer supported since it's not useful without attributes.
+
 ## [1.0.3](https://github.com/folio-org/react-intl-safe-html/tree/v1.0.3) (2019-05-23)
 * Remove all devDeps, which `depcheck` says are all unnecessary. Refs STRIPES-630
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,20 @@
 # react-intl-safe-html
-Sanitized HTML component
 
-Usage:
+Wrapper component over react-intl's `FormattedMessage`. By default, `<FormattedMessage>` requires explicit information about how to render tags. For example:
+```
+<FormattedMessage id="test" values={{ b: (...chunks) => <strong>{chunks}</strong> }} />
+```
+
+This component provides some values "out of the box". They are:
+- `<b>`
+- `<i>`
+- `<em>`
+- `<strong>`
+- `<span>`
+- `<div>`
+
+
+## Usage:
 
 ```
 import SafeHTMLMessage from 'react-intl-safe-html';
@@ -17,25 +30,6 @@ Example translations/en.json:
 }
 ```
 
-By default, `react-intl` will escape HTML in strings to protect the user from dangerous HTML (`script` tags). The `SafeHTMLMessage` component sanitizes HTML strings for safe presentation.
+## Attributes and Styling
 
-### Inline styles
-
-Inline CSS cannot be sanitized, so it is not an allowed attribute. For example, `<span style="color:red">blah</span`. 
-
-> The style attribute and style tags should be consolidated into external stylesheets to protect against a variety of surprisingly clever data exfiltration methods that CSS enables.
-> -- [Web Fundamentals tutorial](https://developers.google.com/web/fundamentals/security/csp/)
-
-Put CSS in its own file (e.g. `About.css`) and reference the class in JavaScript:
-
-```
-<SafeHTMLMessage id='stripes-core.about.example' values={{ className: css.isEmptyMessage }} />
-```
-
-translations/en.json:
-
-```
-{
-  "stripes-core.about.example": "Here is some <span class='{className}'>gray text</span>.",
-}
-```
+If you need to add attributes or styling to a given tag/element, it is recommended that you *do not* use this component and [instead use `FormattedMessage` directly with your own render function.](https://formatjs.io/docs/react-intl/components#rich-text-formatting)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/react-intl-safe-html",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "Sanitized HTML component",
   "main": "src/index.js",
   "repository": "git@github.com:folio-org/react-intl-safe-html.git",
@@ -8,13 +8,10 @@
   "scripts": {
     "build": "webpack --mode production"
   },
-  "devDependencies": {
-  },
+  "dependencies": {},
+  "devDependencies": {},
   "peerDependencies": {
     "react": "^16.3.0",
-    "react-intl": "^2.3.0"
-  },
-  "dependencies": {
-    "sanitize-html": "1.18.2"
+    "react-intl": "^4.5.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,19 +1,24 @@
 import React from 'react';
-import { injectIntl } from 'react-intl';
-import sanitizeHtml from 'sanitize-html';
+import { FormattedMessage } from 'react-intl';
 
-class SafeHTMLMessage extends React.Component {
-  render () {
-    const {intl, id, values, tagName} = this.props;
-    const msg = intl.formatHTMLMessage({id}, values);
-    const options = {
-      allowedTags: [ 'b', 'i', 'em', 'strong', 'a', 'span' ],
-      allowedAttributes: {
-        'a': [ 'href' ],
-        '*': [ 'alt', 'class' ]
-      }
-    }
-    return React.createElement(tagName || 'span', {dangerouslySetInnerHTML:{ __html: sanitizeHtml(msg, options)}}, null);
-  }
-}
-export default injectIntl(SafeHTMLMessage);
+const SafeHTMLMessage = ({
+  id,
+  tagName,
+  values,
+}) => (
+  <FormattedMessage
+    id={id}
+    tagName={tagName}
+    values={{
+      b: (...chunks) => <b>{chunks}</b>,
+      i: (...chunks) => <i>{chunks}</i>,
+      em: (...chunks) => <em>{chunks}</em>,
+      strong: (...chunks) => <strong>{chunks}</strong>,
+      span: (...chunks) => <span>{chunks}</span>,
+      div: (...chunks) => <div>{chunks}</div>,
+      ...values,
+    }}
+  />
+);
+
+export default SafeHTMLMessage;


### PR DESCRIPTION
Due to the changes in react-intl 4.0, we can't do some
of the things we were previously doing such as passing
through attributes.

See: https://github.com/formatjs/formatjs/blob/master/packages/react-intl/CHANGELOG.md#400-2020-03-05

If someone was previously doing `<SafeHTMLMessage id="foo" />` with `foo: "This is <span className='orange'>orange</span>!"`, they'll now need to `<FormattedMessage id="foo" values={{ span: (...chunks) => <span className="orange">{chunks}</span> }} />`.

Note that they would then be able to write their translation strings as just `foo: "This is <span>orange</span>"`, or even `foo: "This is <orangeSpan>orange</orangeSpan>"` if the `values` prop of the `FormattedMessage` was also updated to have an `orangeSpan` key.