### PR TITLE
STRIPES-694 update react-intl to v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for react-intl-safe-html
 
+## 3.0.0 IN PROGRESS
+
+* Support `react-intl` v5. STRIPES-694
+
 ## [2.0.0](https://github.com/folio-org/react-intl-safe-html/tree/v2.0.0) (2020-05-20)
 
 * Support `react-intl` v4. STRIPES-672

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   "devDependencies": {},
   "peerDependencies": {
     "react": "^16.3.0",
-    "react-intl": "^4.5.1"
+    "react-intl": "^5.7.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -10,12 +10,12 @@ const SafeHTMLMessage = ({
     id={id}
     tagName={tagName}
     values={{
-      b: (...chunks) => <b>{chunks}</b>,
-      i: (...chunks) => <i>{chunks}</i>,
-      em: (...chunks) => <em>{chunks}</em>,
-      strong: (...chunks) => <strong>{chunks}</strong>,
-      span: (...chunks) => <span>{chunks}</span>,
-      div: (...chunks) => <div>{chunks}</div>,
+      b: (chunks) => <b>{chunks}</b>,
+      i: (chunks) => <i>{chunks}</i>,
+      em: (chunks) => <em>{chunks}</em>,
+      strong: (chunks) => <strong>{chunks}</strong>,
+      span: (chunks) => <span>{chunks}</span>,
+      div: (chunks) => <div>{chunks}</div>,
       ...values,
     }}
   />


### PR DESCRIPTION
Support `react-intl` `v5`.

Refs [STRIPES-694](https://issues.folio.org/browse/STRIPES-694)