### PR TITLE
show a deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for react-intl-safe-html
 
+## 3.1.0 (IN PROGRESS)
+
+* Add deprecation notice; this component is made obsolete by `react-intl` `v4`.
+
 ## [3.0.0](https://github.com/folio-org/react-intl-safe-html/tree/v3.0.0) (2020-10-16)
 
 * Support `react-intl` v5. STRIPES-694

--- a/src/index.js
+++ b/src/index.js
@@ -5,24 +5,27 @@ const SafeHTMLMessage = ({
   id,
   tagName,
   values,
-}) => (
-  <FormattedMessage
-    id={id}
-    tagName={tagName}
-    values={{
-      b: (chunks) => <b>{chunks}</b>,
-      i: (chunks) => <i>{chunks}</i>,
-      em: (chunks) => <em>{chunks}</em>,
-      strong: (chunks) => <strong>{chunks}</strong>,
-      span: (chunks) => <span>{chunks}</span>,
-      div: (chunks) => <div>{chunks}</div>,
-      p: (chunks) => <p>{chunks}</p>,
-      ul: (chunks) => <ul>{chunks}</ul>,
-      ol: (chunks) => <ol>{chunks}</ol>,
-      li: (chunks) => <li>{chunks}</li>,
-      ...values,
-    }}
-  />
-);
+}) => {
+  console.warn('[DEPRECATION] <SafeHTMLMessage> is deprecated; use <FormattedMessage> from react-intl instead.');
+  return (
+    <FormattedMessage
+      id={id}
+      tagName={tagName}
+      values={{
+        b: (chunks) => <b>{chunks}</b>,
+        i: (chunks) => <i>{chunks}</i>,
+        em: (chunks) => <em>{chunks}</em>,
+        strong: (chunks) => <strong>{chunks}</strong>,
+        span: (chunks) => <span>{chunks}</span>,
+        div: (chunks) => <div>{chunks}</div>,
+        p: (chunks) => <p>{chunks}</p>,
+        ul: (chunks) => <ul>{chunks}</ul>,
+        ol: (chunks) => <ol>{chunks}</ol>,
+        li: (chunks) => <li>{chunks}</li>,
+        ...values,
+      }}
+    />
+  );
+};
 
 export default SafeHTMLMessage;


### PR DESCRIPTION
This component is made obsolete by features added to `react-intl` in
`v4` and incorporated into `stripes-core` in
folio-org/stripes-core/pull/953.